### PR TITLE
fix(worker): don't start request task

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -28,3 +28,11 @@ func TestNewPoolWithQueueTask(t *testing.T) {
 	p.Release()
 	assert.Equal(t, 0, p.BusyWorkers())
 }
+
+func TestPoolNumber(t *testing.T) {
+	p := NewPool(0)
+	p.Start()
+	// shutdown all, and now running worker is 0
+	p.Release()
+	assert.Equal(t, 0, p.BusyWorkers())
+}

--- a/queue.go
+++ b/queue.go
@@ -81,6 +81,9 @@ func NewQueue(opts ...Option) (*Queue, error) {
 
 // Start to enable all worker
 func (q *Queue) Start() {
+	if q.workerCount == 0 {
+		return
+	}
 	q.routineGroup.Run(func() {
 		q.start()
 	})


### PR DESCRIPTION
check worker count is zero or not before fetch the task.

fix https://github.com/golang-queue/queue/issues/59

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>