### PR TITLE
test(benchmark): add queue performance check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Run Tests
         run: |
           go test -v -covermode=atomic -coverprofile=coverage.out
+          go test -v -run=^$ -benchmem -bench .
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/consumer.go
+++ b/consumer.go
@@ -2,12 +2,12 @@ package queue
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/golang-queue/queue/core"
 )
 
@@ -79,13 +79,6 @@ func (s *Consumer) handle(job *Job) error {
 
 // Run to execute new task
 func (s *Consumer) Run(task core.QueuedMessage) error {
-	// var data Job
-	// _ = json.Unmarshal(task.Bytes(), &data)
-	// if v, ok := task.(Job); ok {
-	// 	if v.Task != nil {
-	// 		data.Task = v.Task
-	// 	}
-	// }
 	data := task.(*Job)
 	if data.Task == nil {
 		_ = json.Unmarshal(task.Bytes(), data)

--- a/consumer.go
+++ b/consumer.go
@@ -26,7 +26,7 @@ type Consumer struct {
 	stopFlag  int32
 }
 
-func (s *Consumer) handle(job Job) error {
+func (s *Consumer) handle(job *Job) error {
 	// create channel with buffer size 1 to avoid goroutine leak
 	done := make(chan error, 1)
 	panicChan := make(chan interface{}, 1)
@@ -79,13 +79,18 @@ func (s *Consumer) handle(job Job) error {
 
 // Run to execute new task
 func (s *Consumer) Run(task core.QueuedMessage) error {
-	var data Job
-	_ = json.Unmarshal(task.Bytes(), &data)
-	if v, ok := task.(Job); ok {
-		if v.Task != nil {
-			data.Task = v.Task
-		}
+	// var data Job
+	// _ = json.Unmarshal(task.Bytes(), &data)
+	// if v, ok := task.(Job); ok {
+	// 	if v.Task != nil {
+	// 		data.Task = v.Task
+	// 	}
+	// }
+	data := task.(*Job)
+	if data.Task == nil {
+		_ = json.Unmarshal(task.Bytes(), data)
 	}
+
 	if err := s.handle(data); err != nil {
 		return err
 	}

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -207,7 +207,7 @@ func TestGoroutinePanic(t *testing.T) {
 }
 
 func TestHandleTimeout(t *testing.T) {
-	job := Job{
+	job := &Job{
 		Timeout: 100 * time.Millisecond,
 		Payload: []byte("foo"),
 	}
@@ -222,7 +222,7 @@ func TestHandleTimeout(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, context.DeadlineExceeded, err)
 
-	job = Job{
+	job = &Job{
 		Timeout: 150 * time.Millisecond,
 		Payload: []byte("foo"),
 	}
@@ -245,7 +245,7 @@ func TestHandleTimeout(t *testing.T) {
 }
 
 func TestJobComplete(t *testing.T) {
-	job := Job{
+	job := &Job{
 		Timeout: 100 * time.Millisecond,
 		Payload: []byte("foo"),
 	}
@@ -259,7 +259,7 @@ func TestJobComplete(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, errors.New("job completed"), err)
 
-	job = Job{
+	job = &Job{
 		Timeout: 250 * time.Millisecond,
 		Payload: []byte("foo"),
 	}
@@ -282,7 +282,7 @@ func TestJobComplete(t *testing.T) {
 }
 
 func TestTaskJobComplete(t *testing.T) {
-	job := Job{
+	job := &Job{
 		Timeout: 100 * time.Millisecond,
 		Task: func(ctx context.Context) error {
 			return errors.New("job completed")
@@ -294,7 +294,7 @@ func TestTaskJobComplete(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, errors.New("job completed"), err)
 
-	job = Job{
+	job = &Job{
 		Timeout: 250 * time.Millisecond,
 		Task: func(ctx context.Context) error {
 			return nil
@@ -311,7 +311,7 @@ func TestTaskJobComplete(t *testing.T) {
 	assert.NoError(t, err)
 
 	// job timeout
-	job = Job{
+	job = &Job{
 		Timeout: 50 * time.Millisecond,
 		Task: func(ctx context.Context) error {
 			time.Sleep(60 * time.Millisecond)

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,14 @@ module github.com/golang-queue/queue
 go 1.18
 
 require (
+	github.com/goccy/go-json v0.9.7
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.7.1
 	go.uber.org/goleak v1.1.12
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-json v0.9.7 h1:IcB+Aqpx/iMHu5Yooh7jEzJk1JZ7Pjtmys2ukPr7EeM=
+github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/queue.go
+++ b/queue.go
@@ -2,12 +2,12 @@ package queue
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/golang-queue/queue/core"
 )
 
@@ -47,7 +47,7 @@ type (
 )
 
 // Bytes get string body
-func (j Job) Bytes() []byte {
+func (j *Job) Bytes() []byte {
 	if j.Task != nil {
 		return nil
 	}
@@ -55,8 +55,9 @@ func (j Job) Bytes() []byte {
 }
 
 // Encode for encoding the structure
-func (j Job) Encode() []byte {
+func (j *Job) Encode() []byte {
 	b, _ := json.Marshal(j)
+
 	return b
 }
 
@@ -100,11 +101,11 @@ func (q *Queue) Shutdown() {
 		return
 	}
 
-	if q.metric.BusyWorkers() > 0 {
-		q.logger.Infof("shutdown all tasks: %d workers", q.metric.BusyWorkers())
-	}
-
 	q.stopOnce.Do(func() {
+		if q.metric.BusyWorkers() > 0 {
+			q.logger.Infof("shutdown all tasks: %d workers", q.metric.BusyWorkers())
+		}
+
 		if err := q.worker.Shutdown(); err != nil {
 			q.logger.Error(err)
 		}
@@ -158,13 +159,11 @@ func (q *Queue) handleQueue(timeout time.Duration, job core.QueuedMessage) error
 		return ErrQueueShutdown
 	}
 
-	data := &Job{
-		Timeout: timeout,
-		Payload: job.Bytes(),
-	}
-
 	if err := q.worker.Queue(&Job{
-		Payload: data.Encode(),
+		Payload: (&Job{
+			Timeout: timeout,
+			Payload: job.Bytes(),
+		}).Encode(),
 	}); err != nil {
 		return err
 	}
@@ -189,12 +188,10 @@ func (q *Queue) handleQueueTask(timeout time.Duration, task TaskFunc) error {
 		return ErrQueueShutdown
 	}
 
-	data := &Job{
+	if err := q.worker.Queue(&Job{
 		Timeout: timeout,
 		Task:    task,
-	}
-
-	if err := q.worker.Queue(data); err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/queue.go
+++ b/queue.go
@@ -48,6 +48,9 @@ type (
 
 // Bytes get string body
 func (j Job) Bytes() []byte {
+	if j.Task != nil {
+		return nil
+	}
 	return j.Payload
 }
 
@@ -155,12 +158,12 @@ func (q *Queue) handleQueue(timeout time.Duration, job core.QueuedMessage) error
 		return ErrQueueShutdown
 	}
 
-	data := Job{
+	data := &Job{
 		Timeout: timeout,
 		Payload: job.Bytes(),
 	}
 
-	if err := q.worker.Queue(Job{
+	if err := q.worker.Queue(&Job{
 		Payload: data.Encode(),
 	}); err != nil {
 		return err
@@ -186,14 +189,12 @@ func (q *Queue) handleQueueTask(timeout time.Duration, task TaskFunc) error {
 		return ErrQueueShutdown
 	}
 
-	data := Job{
+	data := &Job{
 		Timeout: timeout,
+		Task:    task,
 	}
 
-	if err := q.worker.Queue(Job{
-		Task:    task,
-		Payload: data.Encode(),
-	}); err != nil {
+	if err := q.worker.Queue(data); err != nil {
 		return err
 	}
 

--- a/queue_test.go
+++ b/queue_test.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -139,4 +140,26 @@ func TestCloseQueueAfterShutdown(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Equal(t, ErrQueueShutdown, err)
+}
+
+func BenchmarkQueueTask(b *testing.B) {
+	q := NewPool(5)
+	q.Release()
+	for n := 0; n < b.N; n++ {
+		_ = q.QueueTask(func(context.Context) error {
+			time.Sleep(10 * time.Millisecond)
+			return nil
+		})
+	}
+}
+
+func BenchmarkQueue(b *testing.B) {
+	m := &mockMessage{
+		message: "foo",
+	}
+	q := NewPool(5)
+	q.Release()
+	for n := 0; n < b.N; n++ {
+		_ = q.Queue(m)
+	}
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -143,17 +143,18 @@ func TestCloseQueueAfterShutdown(t *testing.T) {
 }
 
 func BenchmarkQueueTask(b *testing.B) {
+	b.ReportAllocs()
 	q := NewPool(5)
 	defer q.Release()
 	for n := 0; n < b.N; n++ {
 		_ = q.QueueTask(func(context.Context) error {
-			time.Sleep(10 * time.Millisecond)
 			return nil
 		})
 	}
 }
 
 func BenchmarkQueue(b *testing.B) {
+	b.ReportAllocs()
 	m := &mockMessage{
 		message: "foo",
 	}

--- a/queue_test.go
+++ b/queue_test.go
@@ -144,7 +144,7 @@ func TestCloseQueueAfterShutdown(t *testing.T) {
 
 func BenchmarkQueueTask(b *testing.B) {
 	q := NewPool(5)
-	q.Release()
+	defer q.Release()
 	for n := 0; n < b.N; n++ {
 		_ = q.QueueTask(func(context.Context) error {
 			time.Sleep(10 * time.Millisecond)
@@ -158,7 +158,7 @@ func BenchmarkQueue(b *testing.B) {
 		message: "foo",
 	}
 	q := NewPool(5)
-	q.Release()
+	defer q.Release()
 	for n := 0; n < b.N; n++ {
 		_ = q.Queue(m)
 	}

--- a/worker_task.go
+++ b/worker_task.go
@@ -15,7 +15,7 @@ type taskWorker struct {
 }
 
 func (w *taskWorker) Run(task core.QueuedMessage) error {
-	if v, ok := task.(Job); ok {
+	if v, ok := task.(*Job); ok {
 		if v.Task != nil {
 			_ = v.Task(context.Background())
 		}


### PR DESCRIPTION
## Before

[49894bf](https://github.com/golang-queue/queue/pull/72/commits/49894bf9a85a767e0564f8f8cc1ce75bb2bf60f0)

```sh
goos: linux
goarch: amd64
pkg: github.com/golang-queue/queue
cpu: Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
BenchmarkQueueTask
INFO: 2022/05/29 04:18:27 logger.go:35: shutdown all tasks: 5 workers
BenchmarkQueueTask-2   	     584	   2079968 ns/op	    1801 B/op	      30 allocs/op
BenchmarkQueue
INFO: 2022/05/29 04:18:28 logger.go:35: shutdown all tasks: 5 workers
INFO: 2022/05/29 04:18:28 logger.go:35: shutdown all tasks: 5 workers
INFO: 2022/05/29 04:18:29 logger.go:35: shutdown all tasks: 5 workers
BenchmarkQueue-2       	 1892185	       624.9 ns/op	     214 B/op	       5 allocs/op
PASS
ok  	github.com/golang-queue/queue	2.924s
```

[5d2819e](https://github.com/golang-queue/queue/pull/72/commits/5d2819ea5e4b77e8dd7d8c915e9d2ab4c8370deb)

```sh
goos: linux
goarch: amd64
pkg: github.com/golang-queue/queue
cpu: Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
BenchmarkQueueTask
BenchmarkQueueTask-2   	     582	   2055769 ns/op	    1403 B/op	      22 allocs/op
BenchmarkQueue
INFO: 2022/05/29 06:47:35 logger.go:35: shutdown all tasks: 4 workers
INFO: 2022/05/29 06:47:36 logger.go:35: shutdown all tasks: 5 workers
INFO: 2022/05/29 06:47:37 logger.go:35: shutdown all tasks: 4 workers
BenchmarkQueue-2       	 1996585	       616.1 ns/op	     212 B/op	       5 allocs/op
PASS
ok  	github.com/golang-queue/queue	2.932s
```

[15c43ec](https://github.com/golang-queue/queue/pull/72/commits/15c43eca41b777539a59eff02f47a1274c6d02b3) remove wait time in benchmark

## After

```sh
goos: linux
goarch: amd64
pkg: github.com/golang-queue/queue
cpu: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
BenchmarkQueueTask
INFO: 2022/05/29 14:53:36 logger.go:35: shutdown all tasks: 5 workers
INFO: 2022/05/29 14:53:36 logger.go:35: shutdown all tasks: 4 workers
INFO: 2022/05/29 14:53:37 logger.go:35: shutdown all tasks: 5 workers
INFO: 2022/05/29 14:53:38 logger.go:35: shutdown all tasks: 5 workers
BenchmarkQueueTask-2   	14850574	        86.25 ns/op	      54 B/op	       1 allocs/op
BenchmarkQueue
INFO: 2022/05/29 14:53:38 logger.go:35: shutdown all tasks: 5 workers
INFO: 2022/05/29 14:53:38 logger.go:35: shutdown all tasks: 5 workers
INFO: 2022/05/29 14:53:39 logger.go:35: shutdown all tasks: 5 workers
INFO: 2022/05/29 14:53:40 logger.go:35: shutdown all tasks: 5 workers
BenchmarkQueue-2       	 2270523	       484.3 ns/op	     191 B/op	       4 allocs/op
PASS
ok  	github.com/golang-queue/queue	3.738s
```

