### PR TITLE
chore(consumer): performance tinning

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Run Tests
         run: |
           go test -v -covermode=atomic -coverprofile=coverage.out
+
+      - name: Run Benchmark
+        run: |
           go test -v -run=^$ -benchmem -bench .
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
```sh
BenchmarkConsumerRunUnmarshal
BenchmarkConsumerRunUnmarshal-2   	  494060	      2644 ns/op	     624 B/op	      11 allocs/op
BenchmarkConsumerRunTask
BenchmarkConsumerRunTask-2        	  631615	      2368 ns/op	     592 B/op	      10 allocs/op
PASS
ok  	github.com/golang-queue/queue	6.979s
```

