### PR TITLE
chore(queue): replace channel queue with ring buffer queue.

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -15,9 +15,12 @@ var errMaxCapacity = errors.New("max capacity reached")
 
 // Consumer for simple queue using buffer channel
 type Consumer struct {
-	taskQueue chan core.QueuedMessage
+	taskQueue []core.QueuedMessage
 	runFunc   func(context.Context, core.QueuedMessage) error
-	stop      chan struct{}
+	capacity  int
+	count     int
+	head      int
+	tail      int
 	exit      chan struct{}
 	logger    Logger
 	stopOnce  sync.Once
@@ -36,9 +39,7 @@ func (s *Consumer) Shutdown() error {
 	}
 
 	s.stopOnce.Do(func() {
-		close(s.stop)
-		close(s.taskQueue)
-		if len(s.taskQueue) > 0 {
+		if s.count > 0 {
 			<-s.exit
 		}
 	})
@@ -46,42 +47,68 @@ func (s *Consumer) Shutdown() error {
 }
 
 // Queue send task to the buffer channel
-func (s *Consumer) Queue(task core.QueuedMessage) error {
+func (s *Consumer) Queue(task core.QueuedMessage) error { //nolint:stylecheck
 	if atomic.LoadInt32(&s.stopFlag) == 1 {
 		return ErrQueueShutdown
 	}
-
-	select {
-	case s.taskQueue <- task:
-		return nil
-	default:
+	if s.count >= s.capacity {
 		return errMaxCapacity
 	}
+
+	if s.count == len(s.taskQueue) {
+		s.resize(s.count * 2)
+	}
+	s.taskQueue[s.tail] = task
+	s.tail = (s.tail + 1) % len(s.taskQueue)
+	s.count++
+
+	return nil
 }
 
 // Request a new task from channel
 func (s *Consumer) Request() (core.QueuedMessage, error) {
-	select {
-	case task, ok := <-s.taskQueue:
-		if !ok {
-			select {
-			case s.exit <- struct{}{}:
-			default:
-			}
-			return nil, ErrQueueHasBeenClosed
+	if atomic.LoadInt32(&s.stopFlag) == 1 && s.count == 0 {
+		select {
+		case s.exit <- struct{}{}:
+		default:
 		}
-		return task, nil
-	default:
+		return nil, ErrQueueHasBeenClosed
+	}
+
+	if s.count == 0 {
 		return nil, ErrNoTaskInQueue
 	}
+	data := s.taskQueue[s.head]
+	s.head = (s.head + 1) % len(s.taskQueue)
+	s.count--
+
+	if n := len(s.taskQueue) / 2; n > 2 && s.count <= n {
+		s.resize(n)
+	}
+
+	return data, nil
 }
 
-// NewConsumer for create new consumer instance
+func (q *Consumer) resize(n int) {
+	nodes := make([]core.QueuedMessage, n)
+	if q.head < q.tail {
+		copy(nodes, q.taskQueue[q.head:q.tail])
+	} else {
+		copy(nodes, q.taskQueue[q.head:])
+		copy(nodes[len(q.taskQueue)-q.head:], q.taskQueue[:q.tail])
+	}
+
+	q.tail = q.count % n
+	q.head = 0
+	q.taskQueue = nodes
+}
+
+// NewConsumer for create new Consumer instance
 func NewConsumer(opts ...Option) *Consumer {
 	o := NewOptions(opts...)
 	w := &Consumer{
-		taskQueue: make(chan core.QueuedMessage, o.queueSize),
-		stop:      make(chan struct{}),
+		taskQueue: make([]core.QueuedMessage, 2),
+		capacity:  o.queueSize,
 		exit:      make(chan struct{}),
 		logger:    o.logger,
 		runFunc:   o.fn,


### PR DESCRIPTION
## before (buffer channel queue)

```
goos: linux
goarch: amd64
pkg: github.com/golang-queue/queue
cpu: Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
BenchmarkNewCusumer
BenchmarkNewCusumer-2        	15561048	        81.93 ns/op	       0 B/op	       0 allocs/op
BenchmarkNewCusumer-2        	15640579	        77.76 ns/op	       0 B/op	       0 allocs/op
BenchmarkNewCusumer-2        	15296659	        78.49 ns/op	       0 B/op	       0 allocs/op
BenchmarkNewCusumer-2        	15797636	        77.23 ns/op	       0 B/op	       0 allocs/op
BenchmarkNewCusumer-2        	15114574	        80.24 ns/op	       0 B/op	       0 allocs/op
BenchmarkQueueTask
BenchmarkQueueTask-2         	13314780	        89.42 ns/op	      70 B/op	       1 allocs/op
BenchmarkQueueTask-2         	13111341	        89.77 ns/op	      70 B/op	       1 allocs/op
BenchmarkQueueTask-2         	13126922	        91.31 ns/op	      70 B/op	       1 allocs/op
BenchmarkQueueTask-2         	13230163	        89.56 ns/op	      70 B/op	       1 allocs/op
BenchmarkQueueTask-2         	13422680	        89.07 ns/op	      70 B/op	       1 allocs/op
BenchmarkQueue
BenchmarkQueue-2             	       1	1000485607 ns/op	   86696 B/op	     257 allocs/op
BenchmarkQueue-2             	 1979059	       552.2 ns/op	     256 B/op	       4 allocs/op
BenchmarkQueue-2             	 2003838	       559.9 ns/op	     258 B/op	       4 allocs/op
BenchmarkQueue-2             	 2014424	       582.7 ns/op	     258 B/op	       4 allocs/op
BenchmarkQueue-2             	 1991970	       550.4 ns/op	     257 B/op	       4 allocs/op
BenchmarkConsumerPayload
BenchmarkConsumerPayload-2   	  465771	      2524 ns/op	     624 B/op	      11 allocs/op
BenchmarkConsumerPayload-2   	  445586	      2629 ns/op	     624 B/op	      11 allocs/op
BenchmarkConsumerPayload-2   	  452299	      2614 ns/op	     624 B/op	      11 allocs/op
BenchmarkConsumerPayload-2   	  409573	      2626 ns/op	     624 B/op	      11 allocs/op
BenchmarkConsumerPayload-2   	  388636	      2752 ns/op	     624 B/op	      11 allocs/op
BenchmarkConsumerTask
BenchmarkConsumerTask-2      	  501643	      2425 ns/op	     592 B/op	      10 allocs/op
BenchmarkConsumerTask-2      	  459601	      2374 ns/op	     592 B/op	      10 allocs/op
BenchmarkConsumerTask-2      	  494793	      2421 ns/op	     592 B/op	      10 allocs/op
BenchmarkConsumerTask-2      	  481520	      2341 ns/op	     592 B/op	      10 allocs/op
BenchmarkConsumerTask-2      	  466755	      2332 ns/op	     592 B/op	      10 allocs/op
```

## after (ring buffer queue)

```
goos: linux
goarch: amd64
pkg: github.com/golang-queue/queue
cpu: Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz
BenchmarkNewCusumer
BenchmarkNewCusumer-2        	18284396	        58.51 ns/op	       0 B/op	       0 allocs/op
BenchmarkNewCusumer-2        	20946910	        61.34 ns/op	       0 B/op	       0 allocs/op
BenchmarkNewCusumer-2        	20325073	        59.71 ns/op	       0 B/op	       0 allocs/op
BenchmarkNewCusumer-2        	19505296	        61.19 ns/op	       0 B/op	       0 allocs/op
BenchmarkNewCusumer-2        	18063662	        60.22 ns/op	       0 B/op	       0 allocs/op
BenchmarkQueueTask
BenchmarkQueueTask-2         	  498278	      2057 ns/op	      70 B/op	       1 allocs/op
BenchmarkQueueTask-2         	13277643	        93.76 ns/op	      70 B/op	       1 allocs/op
BenchmarkQueueTask-2         	12950661	        89.85 ns/op	      69 B/op	       1 allocs/op
BenchmarkQueueTask-2         	12792236	        98.14 ns/op	      70 B/op	       1 allocs/op
BenchmarkQueueTask-2         	12772826	        92.96 ns/op	      70 B/op	       1 allocs/op
BenchmarkQueue
BenchmarkQueue-2             	       1	1001118608 ns/op	   21272 B/op	     258 allocs/op
BenchmarkQueue-2             	 1976506	       579.9 ns/op	     260 B/op	       4 allocs/op
BenchmarkQueue-2             	 1829204	       576.3 ns/op	     259 B/op	       4 allocs/op
BenchmarkQueue-2             	 1958416	       579.3 ns/op	     260 B/op	       4 allocs/op
BenchmarkQueue-2             	 1887132	       571.7 ns/op	     260 B/op	       4 allocs/op
BenchmarkConsumerPayload
BenchmarkConsumerPayload-2   	  404334	      2709 ns/op	     624 B/op	      11 allocs/op
BenchmarkConsumerPayload-2   	  407170	      2757 ns/op	     624 B/op	      11 allocs/op
BenchmarkConsumerPayload-2   	  374388	      2755 ns/op	     624 B/op	      11 allocs/op
BenchmarkConsumerPayload-2   	  433399	      2834 ns/op	     624 B/op	      11 allocs/op
BenchmarkConsumerPayload-2   	  422353	      2784 ns/op	     624 B/op	      11 allocs/op
BenchmarkConsumerTask
BenchmarkConsumerTask-2      	  400182	      2514 ns/op	     592 B/op	      10 allocs/op
BenchmarkConsumerTask-2      	  512946	      2488 ns/op	     592 B/op	      10 allocs/op
BenchmarkConsumerTask-2      	  469711	      2543 ns/op	     592 B/op	      10 allocs/op
BenchmarkConsumerTask-2      	  449624	      2488 ns/op	     592 B/op	      10 allocs/op
BenchmarkConsumerTask-2      	  412443	      2534 ns/op	     592 B/op	      10 allocs/op
```

## FInal Result

```
name               old time/op    new time/op    delta
NewCusumer-2         79.1ns ± 4%    60.2ns ± 3%  -23.93%  (p=0.008 n=5+5)
QueueTask-2          89.8ns ± 2%    93.7ns ± 5%   +4.29%  (p=0.032 n=5+4)
Queue-2               561ns ± 4%     577ns ± 1%     ~     (p=0.343 n=4+4)
ConsumerPayload-2    2.63µs ± 5%    2.77µs ± 2%   +5.28%  (p=0.016 n=5+5)
ConsumerTask-2       2.38µs ± 2%    2.51µs ± 1%   +5.67%  (p=0.008 n=5+5)

name               old alloc/op   new alloc/op   delta
NewCusumer-2          0.00B          0.00B          ~     (all equal)
QueueTask-2           70.0B ± 0%     70.0B ± 0%     ~     (all equal)
Queue-2                257B ± 0%      260B ± 0%   +0.97%  (p=0.029 n=4+4)
ConsumerPayload-2      624B ± 0%      624B ± 0%     ~     (all equal)
ConsumerTask-2         592B ± 0%      592B ± 0%     ~     (all equal)

name               old allocs/op  new allocs/op  delta
NewCusumer-2           0.00           0.00          ~     (all equal)
QueueTask-2            1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Queue-2                4.00 ± 0%      4.00 ± 0%     ~     (all equal)
ConsumerPayload-2      11.0 ± 0%      11.0 ± 0%     ~     (all equal)
ConsumerTask-2         10.0 ± 0%      10.0 ± 0%     ~     (all equal)
```

Signed-off-by: Bo-Yi.Wu <appleboy.tw@gmail.com>