### PR TITLE
chore(queue): don't allocate new message

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -47,6 +47,15 @@ func (m *Message) Encode() []byte {
 	return b
 }
 
+// Rest for reset default value
+func (m *Message) Rest() {
+	m.Task = nil
+	m.Payload = nil
+	m.RetryCount = 0
+	m.Timeout = 0
+	m.RetryDelay = 0
+}
+
 func NewMessage(m core.QueuedMessage, opts ...AllowOption) *Message {
 	o := NewOptions(opts...)
 

--- a/queue.go
+++ b/queue.go
@@ -120,10 +120,11 @@ func (q *Queue) Queue(m core.QueuedMessage, opts ...job.AllowOption) error {
 	}
 
 	message := job.NewMessage(m, opts...)
+	payload := message.Encode()
+	message.Rest()
+	message.Payload = payload
 
-	if err := q.worker.Queue(&job.Message{
-		Payload: message.Encode(),
-	}); err != nil {
+	if err := q.worker.Queue(message); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## before

```sh
Run go test -v -run=^$ -count 5 -benchmem -bench . ./...
goos: darwin
goarch: amd64
pkg: github.com/golang-queue/queue
cpu: Intel(R) Xeon(R) CPU E5-2697 v2 @ 2.70GHz
BenchmarkQueue
BenchmarkQueue-3         	 2442654	       498.4 ns/op	     270 B/op	       4 allocs/op
BenchmarkQueue-3         	 2472348	       504.0 ns/op	     270 B/op	       4 allocs/op
BenchmarkQueue-3         	 2351935	       514.6 ns/op	     273 B/op	       4 allocs/op
BenchmarkQueue-3         	 2384654	       517.1 ns/op	     272 B/op	       4 allocs/op
BenchmarkQueue-3         	 2268847	       527.1 ns/op	     275 B/op	       4 allocs/op
```

## After

```sh
54s
Run go test -v -run=^$ -count 5 -benchmem -bench . ./...
goos: darwin
goarch: amd64
pkg: github.com/golang-queue/queue
cpu: Intel(R) Xeon(R) CPU E5-1650 v2 @ 3.50GHz
BenchmarkQueue
BenchmarkQueue-3         	 3307142	       390.1 ns/op	     192 B/op	       3 allocs/op
BenchmarkQueue-3         	 3353919	       393.2 ns/op	     192 B/op	       3 allocs/op
BenchmarkQueue-3         	 3142076	       397.9 ns/op	     194 B/op	       3 allocs/op
BenchmarkQueue-3         	 3212948	       390.7 ns/op	     193 B/op	       3 allocs/op
BenchmarkQueue-3         	 3259310	       367.6 ns/op	     193 B/op	       3 allocs/op
```

## Result

```sh
$ benchstat a.txt b.txt 
name         old time/op    new time/op    delta
Queue-3         512ns ± 3%     388ns ± 5%  -24.27%  (p=0.008 n=5+5)

name         old alloc/op   new alloc/op   delta
Queue-3          272B ± 1%      193B ± 1%  -29.12%  (p=0.008 n=5+5)

name         old allocs/op  new allocs/op  delta
Queue-3          4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.008 n=5+5)
```


Signed-off-by: Bo-Yi.Wu <appleboy.tw@gmail.com>