### PR TITLE
chore(job): serialize a struct to bytes

### DIFF
--- a/core/worker.go
+++ b/core/worker.go
@@ -1,6 +1,8 @@
 package core
 
-import "context"
+import (
+	"context"
+)
 
 // Worker interface
 type Worker interface {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/golang-queue/queue
 go 1.18
 
 require (
-	github.com/goccy/go-json v0.10.0
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/goleak v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/goccy/go-json v0.10.0 h1:mXKd9Qw4NuzShiRlOXKews24ufknHO7gx30lsDyokKA=
-github.com/goccy/go-json v0.10.0/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -1,1 +1,53 @@
 package job
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTaskBinaryEncode(t *testing.T) {
+	m := NewTask(func(context.Context) error {
+		return nil
+	},
+		AllowOption{
+			RetryCount: Int64(100),
+			RetryDelay: Time(30 * time.Millisecond),
+			Timeout:    Time(3 * time.Millisecond),
+		},
+	)
+
+	out := Decode(Encode(m))
+
+	assert.Equal(t, int64(100), out.RetryCount)
+	assert.Equal(t, 30*time.Millisecond, out.RetryDelay)
+}
+
+type mockMessage struct {
+	message string
+}
+
+func (m mockMessage) Bytes() []byte {
+	return []byte(m.message)
+}
+
+func TestMessageBinaryEncode(t *testing.T) {
+	m := NewMessage(&mockMessage{
+		message: "foo",
+	},
+		AllowOption{
+			RetryCount: Int64(100),
+			RetryDelay: Time(30 * time.Millisecond),
+			Timeout:    Time(3 * time.Millisecond),
+		},
+	)
+
+	m.Encode()
+	out := Decode(m.Bytes())
+
+	assert.Equal(t, int64(100), out.RetryCount)
+	assert.Equal(t, 30*time.Millisecond, out.RetryDelay)
+	assert.Equal(t, "foo", string(out.Payload))
+}


### PR DESCRIPTION
See the reference: [Serialize a struct to bytes to send it through the network in Go — Part I](https://medium.com/@maximgradan/serialize-a-struct-to-bytes-to-send-it-through-the-network-in-go-part-i-b861c15d2f06)

```sh
BenchmarkEncode
BenchmarkEncode/JSON
BenchmarkEncode/JSON-2                               	 6139400	       189.3 ns/op	      96 B/op	       1 allocs/op
BenchmarkEncode/JSON-2                               	 6316482	       189.1 ns/op	      96 B/op	       1 allocs/op
BenchmarkEncode/JSON-2                               	 6304340	       189.5 ns/op	      96 B/op	       1 allocs/op
BenchmarkEncode/JSON-2                               	 6285771	       189.5 ns/op	      96 B/op	       1 allocs/op
BenchmarkEncode/JSON-2                               	 6304476	       188.7 ns/op	      96 B/op	       1 allocs/op
BenchmarkEncode/UnsafeCast
BenchmarkEncode/UnsafeCast-2                         	1000000000	         0.5096 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncode/UnsafeCast-2                         	1000000000	         0.5098 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncode/UnsafeCast-2                         	1000000000	         0.5101 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncode/UnsafeCast-2                         	1000000000	         0.5099 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncode/UnsafeCast-2                         	1000000000	         0.5097 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecode
BenchmarkDecode/JSON
BenchmarkDecode/JSON-2                               	 3469248	       344.1 ns/op	      99 B/op	       2 allocs/op
BenchmarkDecode/JSON-2                               	 3480768	       343.9 ns/op	      99 B/op	       2 allocs/op
BenchmarkDecode/JSON-2                               	 3455664	       346.0 ns/op	      99 B/op	       2 allocs/op
BenchmarkDecode/JSON-2                               	 3488086	       343.6 ns/op	      99 B/op	       2 allocs/op
BenchmarkDecode/JSON-2                               	 3478113	       343.5 ns/op	      99 B/op	       2 allocs/op
BenchmarkDecode/UnsafeCast
BenchmarkDecode/UnsafeCast-2                         	1000000000	         0.4021 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecode/UnsafeCast-2                         	1000000000	         0.4021 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecode/UnsafeCast-2                         	1000000000	         0.4023 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecode/UnsafeCast-2                         	1000000000	         0.4022 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecode/UnsafeCast-2                         	1000000000	         0.4023 ns/op	       0 B/op	       0 allocs/op
```

Test Code:

```go
package benchmark

import (
	"testing"
	"time"

	"github.com/golang-queue/queue/job"

	"github.com/goccy/go-json"
	"github.com/stretchr/testify/assert"
)

type mockMessage struct {
	message string
}

func (m mockMessage) Bytes() []byte {
	return []byte(m.message)
}

func BenchmarkEncode(b *testing.B) {
	m := job.NewMessage(&mockMessage{
		message: "foo",
	}, job.AllowOption{
		RetryCount: job.Int64(100),
		RetryDelay: job.Time(30 * time.Millisecond),
		Timeout:    job.Time(3 * time.Millisecond),
	})

	b.Run("JSON", func(b *testing.B) {
		b.ReportAllocs()
		b.ResetTimer()
		for i := 0; i < b.N; i++ {
			_, _ = json.Marshal(m)
		}
	})

	b.Run("UnsafeCast", func(b *testing.B) {
		b.ReportAllocs()
		b.ResetTimer()
		for i := 0; i < b.N; i++ {
			_ = job.Encode(m)
		}
	})
}

func BenchmarkDecode(b *testing.B) {
	m := job.NewMessage(&mockMessage{
		message: "foo",
	}, job.AllowOption{
		RetryCount: job.Int64(100),
		RetryDelay: job.Time(30 * time.Millisecond),
		Timeout:    job.Time(3 * time.Millisecond),
	})

	b.Run("JSON", func(b *testing.B) {
		data, _ := json.Marshal(m)
		out := &job.Message{}
		b.ReportAllocs()
		b.ResetTimer()
		for i := 0; i < b.N; i++ {
			_ = json.Unmarshal(data, out)
		}
	})

	b.Run("UnsafeCast", func(b *testing.B) {
		data := job.Encode(m)
		b.ReportAllocs()
		b.ResetTimer()
		for i := 0; i < b.N; i++ {
			_ = job.Decode(data)
		}
	})
}

func TestEncodeAndDecode(t *testing.T) {
	m := job.NewMessage(&mockMessage{
		message: "foo",
	}, job.AllowOption{
		RetryCount: job.Int64(100),
		RetryDelay: job.Time(30 * time.Millisecond),
		Timeout:    job.Time(3 * time.Millisecond),
	})

	t.Run("JSON", func(t *testing.T) {
		data, _ := json.Marshal(m)
		out := &job.Message{}
		_ = json.Unmarshal(data, out)

		assert.Equal(t, int64(100), out.RetryCount)
		assert.Equal(t, 30*time.Millisecond, out.RetryDelay)
		assert.Equal(t, 3*time.Millisecond, out.Timeout)
	})

	t.Run("UnsafeCast", func(t *testing.T) {
		data := job.Encode(m)
		out := job.Decode(data)

		assert.Equal(t, int64(100), out.RetryCount)
		assert.Equal(t, 30*time.Millisecond, out.RetryDelay)
		assert.Equal(t, 3*time.Millisecond, out.Timeout)
	})
}

```


Signed-off-by: Bo-Yi.Wu <appleboy.tw@gmail.com>