### PR TITLE
refactor(goroutine): improve concurrency safety and testing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,7 +66,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run Tests
         run: |
-          go test -v -covermode=atomic -coverprofile=coverage.out
+          go test -race -v -covermode=atomic -coverprofile=coverage.out
 
       - name: Run Benchmark
         run: |

--- a/queue.go
+++ b/queue.go
@@ -57,7 +57,10 @@ func NewQueue(opts ...Option) (*Queue, error) {
 
 // Start to enable all worker
 func (q *Queue) Start() {
-	if q.workerCount == 0 {
+	q.Lock()
+	count := q.workerCount
+	q.Unlock()
+	if count == 0 {
 		return
 	}
 	q.routineGroup.Run(func() {
@@ -262,7 +265,9 @@ func (q *Queue) handle(m *job.Message) error {
 
 // UpdateWorkerCount to update worker number dynamically.
 func (q *Queue) UpdateWorkerCount(num int) {
+	q.Lock()
 	q.workerCount = num
+	q.Unlock()
 	q.schedule()
 }
 

--- a/ring_test.go
+++ b/ring_test.go
@@ -142,7 +142,7 @@ func TestCancelJobAfterShutdown(t *testing.T) {
 	assert.NoError(t, q.Queue(m, job.AllowOption{Timeout: job.Time(100 * time.Millisecond)}))
 	q.Start()
 	time.Sleep(10 * time.Millisecond)
-	assert.Equal(t, 2, int(q.metric.busyWorkers))
+	assert.Equal(t, 2, q.BusyWorkers())
 	q.Release()
 }
 


### PR DESCRIPTION
- Enable race condition detection in Go tests by adding `-race` flag
- Refactor `Queue` to use a local variable for `workerCount` with proper locking
- Refactor `Ring` to use a local variable for `count` with proper locking and defer unlocking
- Replace direct access to `busyWorkers` metric with `BusyWorkers()` method in tests