### PR TITLE
feat: add ability to call a function after the job function runs

### DIFF
--- a/options.go
+++ b/options.go
@@ -73,6 +73,13 @@ func WithFn(fn func(context.Context, core.QueuedMessage) error) Option {
 	})
 }
 
+// WithAfterFn set callback function after job done
+func WithAfterFn(afterFn func()) Option {
+	return OptionFunc(func(q *Options) {
+		q.afterFn = afterFn
+	})
+}
+
 // Options for custom args in Queue
 type Options struct {
 	workerCount int
@@ -80,6 +87,7 @@ type Options struct {
 	queueSize   int
 	worker      core.Worker
 	fn          func(context.Context, core.QueuedMessage) error
+	afterFn     func()
 	metric      Metric
 }
 

--- a/queue.go
+++ b/queue.go
@@ -29,6 +29,7 @@ type (
 		worker       core.Worker
 		stopOnce     sync.Once
 		stopFlag     int32
+		afterFn      func()
 	}
 )
 
@@ -46,6 +47,7 @@ func NewQueue(opts ...Option) (*Queue, error) {
 		logger:       o.logger,
 		worker:       o.worker,
 		metric:       &metric{},
+		afterFn:      o.afterFn,
 	}
 
 	if q.worker == nil {
@@ -162,6 +164,9 @@ func (q *Queue) work(task core.QueuedMessage) {
 			q.metric.IncSuccessTask()
 		} else {
 			q.metric.IncFailureTask()
+		}
+		if q.afterFn != nil {
+			q.afterFn()
 		}
 	}()
 


### PR DESCRIPTION
From my debugging it seems the `Wait` API will never return until `Shutdown` is called.

I needed a way to reliably know when all jobs were done being called.

This adds a new queue option to call a function after a job is done and the metric counters have been updated in the defer of `work`.

Very simple but allows for an event based tracking on the queue.

If there its a better way, would love to know but this is the solution I am using for now.

Kudos.

@appleboy 