### PR TITLE
feat: add configurable retry interval for queue retries

### DIFF
--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"runtime"
+	"time"
 
 	"github.com/golang-queue/queue/core"
 )
@@ -80,26 +81,35 @@ func WithAfterFn(afterFn func()) Option {
 	})
 }
 
+// WithRetryInterval sets the retry interval
+func WithRetryInterval(d time.Duration) Option {
+	return OptionFunc(func(q *Options) {
+		q.retryInterval = d
+	})
+}
+
 // Options for custom args in Queue
 type Options struct {
-	workerCount int64
-	logger      Logger
-	queueSize   int
-	worker      core.Worker
-	fn          func(context.Context, core.TaskMessage) error
-	afterFn     func()
-	metric      Metric
+	workerCount   int64
+	logger        Logger
+	queueSize     int
+	worker        core.Worker
+	fn            func(context.Context, core.TaskMessage) error
+	afterFn       func()
+	metric        Metric
+	retryInterval time.Duration
 }
 
 // NewOptions initialize the default value for the options
 func NewOptions(opts ...Option) *Options {
 	o := &Options{
-		workerCount: defaultWorkerCount,
-		queueSize:   defaultCapacity,
-		logger:      defaultNewLogger,
-		worker:      nil,
-		fn:          defaultFn,
-		metric:      defaultMetric,
+		workerCount:   defaultWorkerCount,
+		queueSize:     defaultCapacity,
+		logger:        defaultNewLogger,
+		worker:        nil,
+		fn:            defaultFn,
+		metric:        defaultMetric,
+		retryInterval: time.Second,
 	}
 
 	// Loop through each option

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,44 @@
+package queue
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWithRetryInterval(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		want     time.Duration
+	}{
+		{
+			name:     "Set 2 seconds retry interval",
+			duration: 2 * time.Second,
+			want:     2 * time.Second,
+		},
+		{
+			name:     "Set 500ms retry interval",
+			duration: 500 * time.Millisecond,
+			want:     500 * time.Millisecond,
+		},
+		{
+			name:     "Set zero retry interval",
+			duration: 0,
+			want:     0,
+		},
+		{
+			name:     "Set negative retry interval",
+			duration: -1 * time.Second,
+			want:     -1 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := NewOptions(WithRetryInterval(tt.duration))
+			if opts.retryInterval != tt.want {
+				t.Errorf("WithRetryInterval() = %v, want %v", opts.retryInterval, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Import `time` package
- Add `WithRetryInterval` function to set retry intervals
- Add `retryInterval` field to `Options` struct with default value of 1 second
- New file `options_test.go` for testing `WithRetryInterval` functionality with various durations
- Add `retryInterval` field to `Queue` struct
- Initialize ticker with `retryInterval` in `Queue` and update its usage in `start` method

ref: https://github.com/golang-queue/queue/issues/142