### PR TITLE
fix(queue): close TOCTOU race between schedule() and start()

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -30,6 +30,7 @@ type (
 		metric        *metric       // Metrics collector for tracking queue and worker stats
 		logger        Logger        // Logger for queue events and errors
 		workerCount   int64         // Number of worker goroutines to process jobs
+		activeSlots   int64         // Number of reserved worker slots (scheduling guard)
 		routineGroup  *routineGroup // Group to manage and wait for goroutines
 		quit          chan struct{} // Channel to signal shutdown to all goroutines
 		ready         chan struct{} // Channel to signal worker readiness
@@ -185,6 +186,9 @@ func (q *Queue) work(task core.TaskMessage) {
 	// Defer block to handle panics, update metrics, and run afterFn callback.
 	defer func() {
 		q.metric.DecBusyWorker()
+		q.Lock()
+		q.activeSlots--
+		q.Unlock()
 		e := recover()
 		if e != nil {
 			q.logger.Fatalf("panic error: %v", e)
@@ -313,12 +317,12 @@ func (q *Queue) UpdateWorkerCount(num int64) {
 	q.schedule()
 }
 
-// schedule checks if more workers can be started based on the current busy count.
+// schedule checks if more workers can be started based on reserved slots.
 // If so, it signals readiness to start a new worker.
 func (q *Queue) schedule() {
 	q.Lock()
 	defer q.Unlock()
-	if q.BusyWorkers() >= q.workerCount {
+	if q.activeSlots >= q.workerCount {
 		return
 	}
 
@@ -350,6 +354,15 @@ func (q *Queue) start() {
 		case <-q.quit: // Shutdown signal received
 			return
 		}
+
+		// Reserve a slot under the mutex to close the TOCTOU gap.
+		q.Lock()
+		if q.activeSlots >= q.workerCount {
+			q.Unlock()
+			continue
+		}
+		q.activeSlots++
+		q.Unlock()
 
 		// Request a task from the worker in a background goroutine.
 		q.routineGroup.Run(func() {
@@ -386,6 +399,9 @@ func (q *Queue) start() {
 
 		task, ok := <-tasks
 		if !ok {
+			q.Lock()
+			q.activeSlots--
+			q.Unlock()
 			return
 		}
 

--- a/queue.go
+++ b/queue.go
@@ -30,7 +30,7 @@ type (
 		metric        *metric       // Metrics collector for tracking queue and worker stats
 		logger        Logger        // Logger for queue events and errors
 		workerCount   int64         // Number of worker goroutines to process jobs
-		activeSlots   int64         // Reserved slots gating dispatch; incremented before worker.Request(), unlike BusyWorkers which counts only running tasks
+		activeSlots   int64         // Reserved worker slots; see tryReserveSlot/releaseSlot
 		routineGroup  *routineGroup // Group to manage and wait for goroutines
 		quit          chan struct{} // Channel to signal shutdown to all goroutines
 		ready         chan struct{} // Channel to signal worker readiness

--- a/queue.go
+++ b/queue.go
@@ -30,7 +30,7 @@ type (
 		metric        *metric       // Metrics collector for tracking queue and worker stats
 		logger        Logger        // Logger for queue events and errors
 		workerCount   int64         // Number of worker goroutines to process jobs
-		activeSlots   int64         // Number of reserved worker slots (scheduling guard)
+		activeSlots   int64         // Reserved slots gating dispatch; incremented before worker.Request(), unlike BusyWorkers which counts only running tasks
 		routineGroup  *routineGroup // Group to manage and wait for goroutines
 		quit          chan struct{} // Channel to signal shutdown to all goroutines
 		ready         chan struct{} // Channel to signal worker readiness
@@ -186,14 +186,11 @@ func (q *Queue) work(task core.TaskMessage) {
 	// Defer block to handle panics, update metrics, and run afterFn callback.
 	defer func() {
 		q.metric.DecBusyWorker()
-		q.Lock()
-		q.activeSlots--
-		q.Unlock()
+		q.releaseSlot()
 		e := recover()
 		if e != nil {
 			q.logger.Fatalf("panic error: %v", e)
 		}
-		q.schedule()
 
 		// Update success or failure metrics based on execution result.
 		if err == nil && e == nil {
@@ -322,14 +319,40 @@ func (q *Queue) UpdateWorkerCount(num int64) {
 func (q *Queue) schedule() {
 	q.Lock()
 	defer q.Unlock()
+	q.signalReadyLocked()
+}
+
+// signalReadyLocked sends a non-blocking ready signal if a slot is available.
+// Caller must hold q.Lock().
+func (q *Queue) signalReadyLocked() {
 	if q.activeSlots >= q.workerCount {
 		return
 	}
-
 	select {
 	case q.ready <- struct{}{}:
 	default:
 	}
+}
+
+// tryReserveSlot reserves a worker slot if one is available under the mutex,
+// closing the TOCTOU gap between schedule() and dispatch.
+func (q *Queue) tryReserveSlot() bool {
+	q.Lock()
+	defer q.Unlock()
+	if q.activeSlots >= q.workerCount {
+		return false
+	}
+	q.activeSlots++
+	return true
+}
+
+// releaseSlot frees a reserved slot and signals readiness in one critical
+// section, saving a lock round-trip versus separate decrement + schedule().
+func (q *Queue) releaseSlot() {
+	q.Lock()
+	defer q.Unlock()
+	q.activeSlots--
+	q.signalReadyLocked()
 }
 
 /*
@@ -355,14 +378,9 @@ func (q *Queue) start() {
 			return
 		}
 
-		// Reserve a slot under the mutex to close the TOCTOU gap.
-		q.Lock()
-		if q.activeSlots >= q.workerCount {
-			q.Unlock()
+		if !q.tryReserveSlot() {
 			continue
 		}
-		q.activeSlots++
-		q.Unlock()
 
 		// Request a task from the worker in a background goroutine.
 		q.routineGroup.Run(func() {
@@ -399,9 +417,7 @@ func (q *Queue) start() {
 
 		task, ok := <-tasks
 		if !ok {
-			q.Lock()
-			q.activeSlots--
-			q.Unlock()
+			q.releaseSlot()
 			return
 		}
 

--- a/ring_test.go
+++ b/ring_test.go
@@ -564,9 +564,13 @@ func TestBusyWorkersNeverExceedsWorkerCount(t *testing.T) {
 
 	w := NewRing(
 		WithFn(func(ctx context.Context, m core.TaskMessage) error {
-			<-gate
-			wg.Done()
-			return nil
+			defer wg.Done()
+			select {
+			case <-gate:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}),
 	)
 	q, err := NewQueue(
@@ -603,9 +607,14 @@ func TestBusyWorkersNeverExceedsWorkerCount(t *testing.T) {
 		}
 	}()
 
-	// Release tasks in batches to create scheduling pressure.
+	// Release tasks with a timeout to prevent hanging on regression.
+	timeout := time.After(10 * time.Second)
 	for i := 0; i < totalTasks; i++ {
-		gate <- struct{}{}
+		select {
+		case gate <- struct{}{}:
+		case <-timeout:
+			t.Fatal("timed out sending gate tokens — possible scheduling deadlock")
+		}
 	}
 	wg.Wait()
 	close(stop)

--- a/ring_test.go
+++ b/ring_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -557,10 +558,14 @@ func TestBusyWorkersNeverExceedsWorkerCount(t *testing.T) {
 	const totalTasks = 100
 
 	var maxObserved int64
+	var wg sync.WaitGroup
+	wg.Add(totalTasks)
+	gate := make(chan struct{})
 
 	w := NewRing(
 		WithFn(func(ctx context.Context, m core.TaskMessage) error {
-			runtime.Gosched()
+			<-gate
+			wg.Done()
 			return nil
 		}),
 	)
@@ -573,15 +578,37 @@ func TestBusyWorkersNeverExceedsWorkerCount(t *testing.T) {
 	q.Start()
 	for i := 0; i < totalTasks; i++ {
 		assert.NoError(t, q.Queue(mockMessage{message: "task"}))
-		busy := q.BusyWorkers()
+	}
+
+	// Continuously monitor BusyWorkers while tasks execute.
+	stop := make(chan struct{})
+	monitorDone := make(chan struct{})
+	go func() {
+		defer close(monitorDone)
 		for {
-			old := atomic.LoadInt64(&maxObserved)
-			if busy <= old || atomic.CompareAndSwapInt64(&maxObserved, old, busy) {
-				break
+			select {
+			case <-stop:
+				return
+			default:
+				busy := q.BusyWorkers()
+				for {
+					old := atomic.LoadInt64(&maxObserved)
+					if busy <= old || atomic.CompareAndSwapInt64(&maxObserved, old, busy) {
+						break
+					}
+				}
+				runtime.Gosched()
 			}
 		}
+	}()
+
+	// Release tasks in batches to create scheduling pressure.
+	for i := 0; i < totalTasks; i++ {
+		gate <- struct{}{}
 	}
-	time.Sleep(2 * time.Second)
+	wg.Wait()
+	close(stop)
+	<-monitorDone
 	q.Release()
 
 	assert.LessOrEqual(t, maxObserved, int64(workerCount))

--- a/ring_test.go
+++ b/ring_test.go
@@ -585,11 +585,13 @@ func TestBusyWorkersNeverExceedsWorkerCount(t *testing.T) {
 	monitorDone := make(chan struct{})
 	go func() {
 		defer close(monitorDone)
+		ticker := time.NewTicker(100 * time.Microsecond)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-stop:
 				return
-			default:
+			case <-ticker.C:
 				busy := q.BusyWorkers()
 				for {
 					old := atomic.LoadInt64(&maxObserved)
@@ -597,7 +599,6 @@ func TestBusyWorkersNeverExceedsWorkerCount(t *testing.T) {
 						break
 					}
 				}
-				runtime.Gosched()
 			}
 		}
 	}()

--- a/ring_test.go
+++ b/ring_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -549,4 +550,39 @@ func BenchmarkRingQueue(b *testing.B) {
 			}
 		}
 	})
+}
+
+func TestBusyWorkersNeverExceedsWorkerCount(t *testing.T) {
+	const workerCount = 4
+	const totalTasks = 100
+
+	var maxObserved int64
+
+	w := NewRing(
+		WithFn(func(ctx context.Context, m core.TaskMessage) error {
+			runtime.Gosched()
+			return nil
+		}),
+	)
+	q, err := NewQueue(
+		WithWorker(w),
+		WithWorkerCount(workerCount),
+	)
+	assert.NoError(t, err)
+
+	q.Start()
+	for i := 0; i < totalTasks; i++ {
+		assert.NoError(t, q.Queue(mockMessage{message: "task"}))
+		busy := q.BusyWorkers()
+		for {
+			old := atomic.LoadInt64(&maxObserved)
+			if busy <= old || atomic.CompareAndSwapInt64(&maxObserved, old, busy) {
+				break
+			}
+		}
+	}
+	time.Sleep(2 * time.Second)
+	q.Release()
+
+	assert.LessOrEqual(t, maxObserved, int64(workerCount))
 }


### PR DESCRIPTION
## Summary

- Fix a time-of-check-time-of-use race where concurrent `schedule()` calls could observe a stale `BusyWorkers()` value and over-dispatch beyond `workerCount`
- Introduce a mutex-protected `activeSlots` counter that atomically reserves worker slots, eliminating the gap between the scheduling decision and the busy counter increment
- Add regression test `TestBusyWorkersNeverExceedsWorkerCount` that validates the invariant under concurrency pressure

## Root Cause

`schedule()` checked `BusyWorkers()` under the mutex and sent on the `ready` channel, but `IncBusyWorker()` in `start()` happened much later — after receiving from ready, spawning a request goroutine, and waiting for a task. During this window, concurrent `schedule()` calls (from `work()` defers) saw stale values and could send extra ready signals.

## Approach

Added an internal `activeSlots int64` field that tracks reserved (committed) worker slots. Both `schedule()` and `start()` check/modify this counter under the same mutex, closing the TOCTOU gap entirely. The public `BusyWorkers()` metric remains unchanged — it still only counts workers actively executing tasks.

## Test plan

- [x] `go test -race -v ./...` — all existing tests pass
- [x] `go test -race -count=50 -run=TestBusyWorkersNeverExceedsWorkerCount` — stress test passes
- [x] `go test -race -count=10 -run=TestDecreaseWorkerCount` — dynamic worker count still works
- [x] Benchmarks show no regression (0 additional allocations)

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)